### PR TITLE
Enable password autofill metadata for iOS authentication screens

### DIFF
--- a/ios/BarkPark/BarkPark/Features/Authentication/Views/LoginView.swift
+++ b/ios/BarkPark/BarkPark/Features/Authentication/Views/LoginView.swift
@@ -60,8 +60,14 @@ struct LoginView: View {
                             HStack {
                                 if showPassword {
                                     TextField("Enter your password", text: $password)
+                                        .textContentType(.password)
+                                        .textInputAutocapitalization(.never)
+                                        .autocorrectionDisabled(true)
                                 } else {
                                     SecureField("Enter your password", text: $password)
+                                        .textContentType(.password)
+                                        .textInputAutocapitalization(.never)
+                                        .autocorrectionDisabled(true)
                                 }
                                 
                                 Button {

--- a/ios/BarkPark/BarkPark/Features/Authentication/Views/ResetPasswordView.swift
+++ b/ios/BarkPark/BarkPark/Features/Authentication/Views/ResetPasswordView.swift
@@ -66,9 +66,15 @@ struct ResetPasswordView: View {
                                 HStack {
                                     if showPassword {
                                         TextField("At least 6 characters", text: $viewModel.newPassword)
+                                            .textContentType(.newPassword)
+                                            .textInputAutocapitalization(.never)
+                                            .autocorrectionDisabled(true)
                                             .textFieldStyle(BarkParkTextFieldStyle())
                                     } else {
                                         SecureField("At least 6 characters", text: $viewModel.newPassword)
+                                            .textContentType(.newPassword)
+                                            .textInputAutocapitalization(.never)
+                                            .autocorrectionDisabled(true)
                                             .textFieldStyle(BarkParkTextFieldStyle())
                                     }
                                     
@@ -89,9 +95,15 @@ struct ResetPasswordView: View {
                                 HStack {
                                     if showConfirmPassword {
                                         TextField("Re-enter password", text: $viewModel.confirmPassword)
+                                            .textContentType(.newPassword)
+                                            .textInputAutocapitalization(.never)
+                                            .autocorrectionDisabled(true)
                                             .textFieldStyle(BarkParkTextFieldStyle())
                                     } else {
                                         SecureField("Re-enter password", text: $viewModel.confirmPassword)
+                                            .textContentType(.newPassword)
+                                            .textInputAutocapitalization(.never)
+                                            .autocorrectionDisabled(true)
                                             .textFieldStyle(BarkParkTextFieldStyle())
                                     }
                                     

--- a/ios/BarkPark/BarkPark/Features/Authentication/Views/SignUpView.swift
+++ b/ios/BarkPark/BarkPark/Features/Authentication/Views/SignUpView.swift
@@ -95,8 +95,14 @@ struct SignUpView: View {
                             HStack {
                                 if showPassword {
                                     TextField("Enter your password", text: $password)
+                                        .textContentType(.newPassword)
+                                        .textInputAutocapitalization(.never)
+                                        .autocorrectionDisabled(true)
                                 } else {
                                     SecureField("Enter your password", text: $password)
+                                        .textContentType(.newPassword)
+                                        .textInputAutocapitalization(.never)
+                                        .autocorrectionDisabled(true)
                                 }
                                 
                                 Button {
@@ -122,8 +128,14 @@ struct SignUpView: View {
                             HStack {
                                 if showConfirmPassword {
                                     TextField("Confirm your password", text: $confirmPassword)
+                                        .textContentType(.newPassword)
+                                        .textInputAutocapitalization(.never)
+                                        .autocorrectionDisabled(true)
                                 } else {
                                     SecureField("Confirm your password", text: $confirmPassword)
+                                        .textContentType(.newPassword)
+                                        .textInputAutocapitalization(.never)
+                                        .autocorrectionDisabled(true)
                                 }
                                 
                                 Button {

--- a/ios/BarkPark/BarkPark/Features/Profile/Views/AccountSettingsView.swift
+++ b/ios/BarkPark/BarkPark/Features/Profile/Views/AccountSettingsView.swift
@@ -313,11 +313,20 @@ struct ChangePasswordView: View {
             Form {
                 Section("Current Password") {
                     SecureField("Current Password", text: $currentPassword)
+                        .textContentType(.password)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
                 }
-                
+
                 Section("New Password") {
                     SecureField("New Password", text: $newPassword)
+                        .textContentType(.newPassword)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
                     SecureField("Confirm New Password", text: $confirmPassword)
+                        .textContentType(.newPassword)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
                 }
                 
                 Section {


### PR DESCRIPTION
## Summary
- add password text content types to login, signup, reset, and change password inputs so iOS surfaces autofill
- disable autocapitalization and autocorrect on password fields to avoid interfering with credential entry

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e47e1e7b2883218d9809e1710beddb