### PR TITLE
feat: include dog matches in auth search

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -305,23 +305,53 @@ router.get('/search', verifyToken, [
     const currentUserId = req.user.id;
 
     const query = `
-      SELECT id, email, first_name, last_name, phone, profile_image_url, is_searchable
-      FROM users
-      WHERE id != $1 
-        AND is_searchable = true
+      SELECT
+        u.id,
+        u.email,
+        u.first_name,
+        u.last_name,
+        u.phone,
+        u.profile_image_url,
+        u.is_searchable,
+        COALESCE(
+          json_agg(
+            json_build_object(
+              'id', d.id,
+              'name', d.name
+            )
+          ) FILTER (WHERE d.id IS NOT NULL),
+          '[]'::json
+        ) AS dogs
+      FROM users u
+      LEFT JOIN dogs d ON d.user_id = u.id
+      WHERE u.id != $1
+        AND u.is_searchable = true
         AND (
-          LOWER(first_name) LIKE LOWER($2) OR
-          LOWER(last_name) LIKE LOWER($2) OR
-          LOWER(CONCAT(first_name, ' ', last_name)) LIKE LOWER($2) OR
-          LOWER(email) LIKE LOWER($2)
+          LOWER(u.first_name) LIKE LOWER($2) OR
+          LOWER(u.last_name) LIKE LOWER($2) OR
+          LOWER(CONCAT(u.first_name, ' ', u.last_name)) LIKE LOWER($2) OR
+          LOWER(u.email) LIKE LOWER($2) OR
+          EXISTS (
+            SELECT 1
+            FROM dogs d2
+            WHERE d2.user_id = u.id
+              AND LOWER(d2.name) LIKE LOWER($2)
+          )
         )
-      ORDER BY 
-        CASE 
-          WHEN LOWER(CONCAT(first_name, ' ', last_name)) LIKE LOWER($3) THEN 1
-          WHEN LOWER(first_name) LIKE LOWER($3) OR LOWER(last_name) LIKE LOWER($3) THEN 2
-          ELSE 3
+      GROUP BY u.id, u.email, u.first_name, u.last_name, u.phone, u.profile_image_url, u.is_searchable
+      ORDER BY
+        CASE
+          WHEN LOWER(CONCAT(u.first_name, ' ', u.last_name)) LIKE LOWER($3) THEN 1
+          WHEN LOWER(u.first_name) LIKE LOWER($3) OR LOWER(u.last_name) LIKE LOWER($3) THEN 2
+          WHEN EXISTS (
+            SELECT 1
+            FROM dogs d3
+            WHERE d3.user_id = u.id
+              AND LOWER(d3.name) LIKE LOWER($3)
+          ) THEN 3
+          ELSE 4
         END,
-        first_name, last_name
+        u.first_name, u.last_name
       LIMIT 20
     `;
 
@@ -340,7 +370,8 @@ router.get('/search', verifyToken, [
       phone: user.phone,
       profileImageUrl: user.profile_image_url,
       isSearchable: user.is_searchable,
-      fullName: `${user.first_name} ${user.last_name}`
+      fullName: `${user.first_name} ${user.last_name}`,
+      dogs: Array.isArray(user.dogs) ? user.dogs : []
     }));
 
     res.json({

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const authRoutes = require('../routes/auth');
 const User = require('../models/User');
+const Dog = require('../models/Dog');
 
 // Create test app
 const createTestApp = () => {
@@ -286,6 +287,67 @@ describe('Authentication API', () => {
         .expect(400);
 
       expect(response.body).toHaveProperty('errors');
+    });
+  });
+
+  describe('GET /api/auth/search', () => {
+    let authToken;
+
+    beforeEach(async () => {
+      const searchUser = {
+        email: 'searcher@example.com',
+        password: 'password123',
+        firstName: 'Search',
+        lastName: 'User'
+      };
+
+      const registerResponse = await request(app)
+        .post('/api/auth/register')
+        .send(searchUser)
+        .expect(201);
+
+      authToken = registerResponse.body.token;
+    });
+
+    it('should return users when a dog name matches the query', async () => {
+      const ownerUser = {
+        email: 'owner@example.com',
+        password: 'password123',
+        firstName: 'Dog',
+        lastName: 'Owner'
+      };
+
+      const ownerRegisterResponse = await request(app)
+        .post('/api/auth/register')
+        .send(ownerUser)
+        .expect(201);
+
+      const ownerId = ownerRegisterResponse.body.user.id;
+      const dogName = 'Fido Searchable';
+
+      await Dog.create({
+        userId: ownerId,
+        name: dogName,
+        breed: 'Beagle'
+      });
+
+      const response = await request(app)
+        .get('/api/auth/search')
+        .set('Authorization', `Bearer ${authToken}`)
+        .query({ q: 'Fido' })
+        .expect(200);
+
+      expect(response.body.count).toBeGreaterThanOrEqual(1);
+      const matchedUser = response.body.users.find(user => user.id === ownerId);
+      expect(matchedUser).toBeDefined();
+      expect(matchedUser.dogs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: dogName,
+            id: expect.any(Number)
+          })
+        ])
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- update the auth search query to match against dog names and aggregate owners' dogs
- include dog summaries in the search response payload
- add a test ensuring a user is found when searching by their dog's name

## Testing
- npm test -- tests/auth.test.js *(fails: test database setup error)*

------
https://chatgpt.com/codex/tasks/task_e_68e47f3985f48321a004f2a590653b89